### PR TITLE
fix: Highlight `if` as keyword after case item colon

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -7,8 +7,9 @@ variables:
   identifier: (?:${simpleIdentifier}|${escapeIdentifier})
   identifierNotKeyword: (?:${simpleIdentifier}|${escapeIdentifier})(?<!${keywords})
   macro: (?:`[a-zA-Z_][a-zA-Z0-9_\$]*\b(?:\(.*?\))?)(?<!`(?:__FILE__|__LINE__|begin_keywords|celldefine|default_nettype|define|else|elsif|end_keywords|endcelldefine|endif|ifdef|ifndef|include|line|nounconnected_drive|pragma|resetall|timescale|unconnected_drive|undef|undefineall)\b)
-  # Remove array method name: unique, and, or, xor
-  functionIdentifier: ${identifier}(?<!\btype\b)
+  # Function identifiers cannot be keywords (if, case, for, etc.)
+  # Array methods like unique, and, or, xor are explicitly added where needed
+  functionIdentifier: ${identifierNotKeyword}
   classScope: (?:${identifier}\s*(?:\#\(.*?\)\s*)?::\s*)+
   # Identifier can be followed by ":" (ternary statement, label, etc.)
   # Identifier cannot be followed by another identifier

--- a/tests/chapter-12/12.5--case.sv
+++ b/tests/chapter-12/12.5--case.sv
@@ -36,6 +36,8 @@ module case_tb ();
       default b = 0;
 //    ^^^^^^^^^^^^^^ meta.case-statement.sv
 //    ^^^^^^^ keyword.control.default.sv
+      4'h1: if (a) b = 1;
+//          ^^ keyword.control.if.sv
     endcase
 //  ^^^^^^^ meta.case-statement.sv
 //  ^^^^^^^ keyword.control.endcase.sv


### PR DESCRIPTION
## Summary
- Change `functionIdentifier` to use `identifierNotKeyword` to exclude control keywords
- Add test case for `if` statement after case item colon

## Test plan
- [x] Added test case in `tests/chapter-12/12.5--case.sv`
- [x] All 877 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)