### PR TITLE
Fix 'return' incorrectly highlighted as type name

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6565,7 +6565,8 @@ repository:
       - match: (\b[A-Z][a-zA-Z0-9_\$]*)\s*(?=\')
         captures:
           "1": { name: variable.other.constant.sv }
-      - match: (${simpleIdentifier})\s*(?=\')
+      # Keywords (like 'return') followed by '{ should not match as type cast
+      - match: (${identifierNotKeyword})\s*(?=\')
         captures:
           "1": { name: entity.name.type.sv }
       - include: "#primary-literal"
@@ -6619,7 +6620,8 @@ repository:
       - match: (\b[A-Z][a-zA-Z0-9_\$]*)\s*(?=\')
         captures:
           "1": { name: variable.other.constant.sv }
-      - match: (${simpleIdentifier})\s*(?=\')
+      # Keywords (like 'return') followed by '{ should not match as type cast
+      - match: (${identifierNotKeyword})\s*(?=\')
         captures:
           "1": { name: entity.name.type.sv }
       - include: "#primary-literal"

--- a/tests/chapter-06/6.24.1--cast_op.sv
+++ b/tests/chapter-06/6.24.1--cast_op.sv
@@ -14,7 +14,7 @@
 */
 module top();
   int a = int'(2.1 * 3.7);
-//        ^^^ entity.name.type.sv
+//        ^^^ entity.name.type.int.sv
 //           ^ punctuation.definition.casting.sv
 //            ^ punctuation.section.group.begin.sv
 //             ^^^ constant.numeric.real.sv

--- a/tests/chapter-06/6.24.3--bitstream_cast.sv
+++ b/tests/chapter-06/6.24.3--bitstream_cast.sv
@@ -18,7 +18,7 @@ module top();
 //^^^^^^^ entity.name.type.integer.sv
 //        ^ variable.other.sv
 //          ^ keyword.operator.assignment.sv
-//            ^^^^^^^ entity.name.type.sv
+//            ^^^^^^^ entity.name.type.integer.sv
 //                   ^ punctuation.definition.casting.sv
 //                    ^ punctuation.section.group.begin.sv
 //                     ^ variable.other.sv

--- a/tests/chapter-12/misc.sv
+++ b/tests/chapter-12/misc.sv
@@ -1,0 +1,26 @@
+// SYNTAX TEST "source-text.sv"
+
+// Real-world patterns for chapter 12 (procedural programming statements)
+
+module test;
+  typedef struct {
+    int field_1;
+    int field_2;
+  } my_struct_t;
+
+  // Return with assignment pattern
+  function my_struct_t get_struct(input int a);
+    return '{ field_1: a, field_2: 0 };
+//  ^^^^^^ keyword.control.return.sv
+  endfunction
+
+  // Return in case statement
+  function my_struct_t case_return(input int sel);
+    case (sel)
+      0: return '{ field_1: 0, field_2: 1 };
+//       ^^^^^^ keyword.control.return.sv
+      default: return '{ default: 0 };
+//             ^^^^^^ keyword.control.return.sv
+    endcase
+  endfunction
+endmodule


### PR DESCRIPTION
## Summary
- Fix `return '{ ... }` being incorrectly highlighted as a type cast
- `return` followed by assignment pattern was matching the type cast pattern `identifier'(...)`
- Use `${identifierNotKeyword}` to exclude statement keywords from type cast matching

## Test plan
- [x] Added `tests/chapter-12/misc.sv` with test cases for `return '{ ... }` in case statements
- [x] All existing tests pass
- [x] Updated cast test assertions to expect specific type scopes