### PR TITLE
Standardize type scopes to generic entity.name.type.sv

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -1385,7 +1385,7 @@ repository:
     patterns:
       - match: ${keywordStart}\b(interconnect)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - include: "#net-type"
       - include: "#drive-strength"
       - include: "#charge-strength"
@@ -1453,7 +1453,7 @@ repository:
       - include: "#signing"
       - match: \b(string)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - match: \b(const)\b\s*
         captures:
           "1": { name: storage.modifier.$1.sv }
@@ -1537,10 +1537,10 @@ repository:
               - include: "#comma"
       - match: \b(string)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - match: \b(chandle)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - match: \b(virtual)\b\s*(?!class|function|task)(?:\b(interface)\b\s*)?(${identifier})\s*
         captures:
           "1": { name: storage.modifier.virtual.sv }
@@ -1554,7 +1554,7 @@ repository:
       - include: "#class-type"
       - match: \b(event)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - include: "#ps-covergroup-identifier"
       - include: "#type-reference"
   data-type-or-implicit:
@@ -1621,24 +1621,24 @@ repository:
   integer-atom-type:
     match: \b(byte|shortint|int|longint|integer|time)\b\s*
     captures:
-      "1": { name: entity.name.type.$1.sv }
+      "1": { name: entity.name.type.sv }
   integer-vector-type:
     match: \b(bit|logic|reg)\b\s*
     captures:
-      "1": { name: entity.name.type.$1.sv }
+      "1": { name: entity.name.type.sv }
   non-integer-type:
     match: \b(shortreal|real|realtime)\b\s*
     captures:
-      "1": { name: entity.name.type.$1.sv }
+      "1": { name: entity.name.type.sv }
   net-type:
     match: \b(supply0|supply1|tri|triand|trior|trireg|tri0|tri1|uwire|wire|wand|wor)\b\s*
     captures:
-      "1": { name: entity.name.type.$1.sv }
+      "1": { name: entity.name.type.sv }
   net-port-type:
     patterns:
       - match: \b(interconnect)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - include: "#net-type"
       - include: "#net-type-identifier"
       - include: "#implicit-data-type"
@@ -1693,7 +1693,7 @@ repository:
     patterns:
       - match: \b(void)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - include: "#data-type"
   struct-union:
     patterns:
@@ -2521,7 +2521,7 @@ repository:
       - include: "#sequence-formal-type"
       - match: \b(property)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
   property-spec:
     patterns:
       - name: meta.property-spec.sv
@@ -2821,7 +2821,7 @@ repository:
     patterns:
       - match: \b(sequence)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - match: \b(untyped)\b\s*
         captures:
           "1": { name: storage.modifier.$1.sv }
@@ -3978,7 +3978,7 @@ repository:
     patterns:
       - match: ${keywordStart}\b(genvar)\b\s*
         captures:
-          "1": { name: entity.name.type.$1.sv }
+          "1": { name: entity.name.type.sv }
       - include: "#genvar-identifier"
   genvar-iteration:
     patterns:
@@ -7398,7 +7398,7 @@ repository:
     match: (`default_nettype)\b\s*(?:\b(wire|tri|tri0|tri1|wand|triand|wor|trior|trireg|uwire|none)\b)?
     captures:
       "1": { name: keyword.control.default-nettype.sv }
-      "2": { name: entity.name.type.$2.sv }
+      "2": { name: entity.name.type.sv }
   macro-nounconnected-drive:
     match: (`nounconnected_drive)\b\s*
     captures:

--- a/tests/chapter-05/5.10-structures.sv
+++ b/tests/chapter-05/5.10-structures.sv
@@ -34,18 +34,18 @@ module top();
 //                 ^ punctuation.separator.colon.sv
 //                  ^ constant.numeric.integer.sv
 //                   ^ punctuation.separator.comma.sv
-//                     ^^^ entity.name.type.int.sv
+//                     ^^^ entity.name.type.sv
 //                        ^ punctuation.separator.colon.sv
 //                         ^ constant.numeric.integer.sv
 //                          ^ punctuation.section.braces.end.sv
 
     ms = '{ int:0, int:1};
 //       ^^ punctuation.section.braces.begin.sv
-//          ^^^ entity.name.type.int.sv
+//          ^^^ entity.name.type.sv
 //             ^ punctuation.separator.colon.sv
 //              ^ constant.numeric.integer.sv
 //               ^ punctuation.separator.comma.sv
-//                 ^^^ entity.name.type.int.sv
+//                 ^^^ entity.name.type.sv
 //                    ^ punctuation.separator.colon.sv
 //                     ^ constant.numeric.integer.sv
   end

--- a/tests/chapter-05/5.6.4--compiler-directives-default-nettype.sv
+++ b/tests/chapter-05/5.6.4--compiler-directives-default-nettype.sv
@@ -15,9 +15,9 @@
 
 `default_nettype wire
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.wire.sv
+//               ^^^^ entity.name.type.sv
 `default_nettype none
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.none.sv
+//               ^^^^ entity.name.type.sv
 module dn();
 endmodule

--- a/tests/chapter-05/5.7.1--integers-token.sv
+++ b/tests/chapter-05/5.7.1--integers-token.sv
@@ -14,5 +14,5 @@
 */
 module top();
   integer a;
-//^^^^^^^ entity.name.type.integer.sv
+//^^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-05/5.7.2-real-token.sv
+++ b/tests/chapter-05/5.7.2-real-token.sv
@@ -14,5 +14,5 @@
 */
 module top();
   real a;
-//^^^^ entity.name.type.real.sv
+//^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.12--real.sv
+++ b/tests/chapter-06/6.12--real.sv
@@ -14,5 +14,5 @@
 */
 module top();
   real a = 0.5;
-//^^^^ entity.name.type.real.sv
+//^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.12--realtime.sv
+++ b/tests/chapter-06/6.12--realtime.sv
@@ -14,5 +14,5 @@
 */
 module top();
   realtime a = 0.5;
-//^^^^^^^^ entity.name.type.realtime.sv
+//^^^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.12--shortreal.sv
+++ b/tests/chapter-06/6.12--shortreal.sv
@@ -14,5 +14,5 @@
 */
 module top();
   shortreal a = 0.5;
-//^^^^^^^^^ entity.name.type.shortreal.sv
+//^^^^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.13--void.sv
+++ b/tests/chapter-06/6.13--void.sv
@@ -15,7 +15,7 @@
 */
 module top();
   function void fun();
-//         ^^^^ entity.name.type.void.sv
+//         ^^^^ entity.name.type.sv
     $display(":assert:(True)");
   endfunction
 

--- a/tests/chapter-06/6.14--chandle.sv
+++ b/tests/chapter-06/6.14--chandle.sv
@@ -14,5 +14,5 @@
 */
 module top();
   chandle a;
-//^^^^^^^ entity.name.type.chandle.sv
+//^^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.16--string.sv
+++ b/tests/chapter-06/6.16--string.sv
@@ -14,5 +14,5 @@
 */
 module top();
   string a;
-//^^^^^^ entity.name.type.string.sv
+//^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.17--event.sv
+++ b/tests/chapter-06/6.17--event.sv
@@ -14,5 +14,5 @@
 */
 module top();
   event a;
-//^^^^^ entity.name.type.event.sv
+//^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.18--typedef.sv
+++ b/tests/chapter-06/6.18--typedef.sv
@@ -15,7 +15,7 @@
 module top();
   typedef logic logic_t;
 //^^^^^^^ keyword.control.typedef.sv
-//        ^^^^^ entity.name.type.logic.sv
+//        ^^^^^ entity.name.type.sv
 //              ^^^^^^^ entity.name.type.sv
   logic_t a;
 //^^^^^^^ entity.name.type.sv

--- a/tests/chapter-06/6.19--enum_value_inv.sv
+++ b/tests/chapter-06/6.19--enum_value_inv.sv
@@ -23,7 +23,7 @@ module top();
   enum logic [2:0] {
 //^^^^^^^^^^^^^^^^^^ meta.enum.sv
 //^^^^ storage.type.enum.sv
-//     ^^^^^ entity.name.type.logic.sv
+//     ^^^^^ entity.name.type.sv
 //           ^^^^^ meta.dimension.sv
 //                 ^ punctuation.section.braces.begin.sv
     Global = 4'h2,

--- a/tests/chapter-06/6.19.4--enum_numerical_expr.sv
+++ b/tests/chapter-06/6.19.4--enum_numerical_expr.sv
@@ -17,7 +17,7 @@ module top();
 
   initial begin
     integer i;
-//  ^^^^^^^ entity.name.type.integer.sv
+//  ^^^^^^^ entity.name.type.sv
 //          ^ variable.other.sv
     e val;
 //  ^ entity.name.type.sv

--- a/tests/chapter-06/6.20.2--parameter_aggregate.sv
+++ b/tests/chapter-06/6.20.2--parameter_aggregate.sv
@@ -15,7 +15,7 @@
 module top();
   parameter logic [31:0] p [3:0] = '{1, 2, 3, 4};
 //^^^^^^^^^ storage.modifier.parameter.sv
-//          ^^^^^ entity.name.type.logic.sv
+//          ^^^^^ entity.name.type.sv
 //                ^^^^^^ meta.dimension.sv
 //                       ^ variable.other.constant.sv
 //                         ^^^^^ meta.dimension.sv

--- a/tests/chapter-06/6.20.3--parameter_type.sv
+++ b/tests/chapter-06/6.20.3--parameter_type.sv
@@ -17,5 +17,5 @@ module top #(type T = real);
 //           ^^^^ storage.type.type.sv
 //                ^ entity.name.type.sv
 //                  ^ keyword.operator.assignment.sv
-//                    ^^^^ entity.name.type.real.sv
+//                    ^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.20.4--localparam_int.sv
+++ b/tests/chapter-06/6.20.4--localparam_int.sv
@@ -15,7 +15,7 @@
 module top();
   localparam int p = 123;
 //^^^^^^^^^^ storage.modifier.localparam.sv
-//           ^^^ entity.name.type.int.sv
+//           ^^^ entity.name.type.sv
 //               ^ variable.other.constant.sv
 //                 ^ keyword.operator.assignment.sv
 //                   ^^^ constant.numeric.integer.sv

--- a/tests/chapter-06/6.20.4--localparam_logic.sv
+++ b/tests/chapter-06/6.20.4--localparam_logic.sv
@@ -19,7 +19,7 @@ module top();
 //                  ^ variable.other.constant.sv
   localparam logic [10:0] q = 1 << 5;
 //^^^^^^^^^^ storage.modifier.localparam.sv
-//           ^^^^^ entity.name.type.logic.sv
+//           ^^^^^ entity.name.type.sv
 //                 ^^^^^^ meta.dimension.sv
 //                        ^ variable.other.constant.sv
 endmodule

--- a/tests/chapter-06/6.20.4--localparam_string.sv
+++ b/tests/chapter-06/6.20.4--localparam_string.sv
@@ -16,6 +16,6 @@ module top();
   localparam s1 = "foo";
   localparam string s2 = "bar";
 //^^^^^^^^^^ storage.modifier.localparam.sv
-//           ^^^^^^ entity.name.type.string.sv
+//           ^^^^^^ entity.name.type.sv
 //                  ^^ variable.other.constant.sv
 endmodule

--- a/tests/chapter-06/6.20.4--localparam_unsigned_int.sv
+++ b/tests/chapter-06/6.20.4--localparam_unsigned_int.sv
@@ -15,7 +15,7 @@
 module top();
   localparam int unsigned q = 123;
 //^^^^^^^^^^ storage.modifier.localparam.sv
-//           ^^^ entity.name.type.int.sv
+//           ^^^ entity.name.type.sv
 //               ^^^^^^^^ storage.modifier.unsigned.sv
 //                        ^ variable.other.constant.sv
 endmodule

--- a/tests/chapter-06/6.23--type_op_compare.sv
+++ b/tests/chapter-06/6.23--type_op_compare.sv
@@ -30,7 +30,7 @@ module top #( parameter type T = type(logic[11:0]) )
 //      ^^^^^^^^^^^^^^^^^ meta.type-reference.sv
 //      ^^^^ keyword.other.type.sv
 //          ^ punctuation.section.group.begin.sv
-//           ^^^^^ entity.name.type.logic.sv
+//           ^^^^^ entity.name.type.sv
 //                ^^^^^^ meta.dimension.sv
 //                      ^ punctuation.section.group.end.sv
         default           : $stop;

--- a/tests/chapter-06/6.24.1--cast_op.sv
+++ b/tests/chapter-06/6.24.1--cast_op.sv
@@ -14,7 +14,7 @@
 */
 module top();
   int a = int'(2.1 * 3.7);
-//        ^^^ entity.name.type.int.sv
+//        ^^^ entity.name.type.sv
 //           ^ punctuation.definition.casting.sv
 //            ^ punctuation.section.group.begin.sv
 //             ^^^ constant.numeric.real.sv

--- a/tests/chapter-06/6.24.3--bitstream_cast.sv
+++ b/tests/chapter-06/6.24.3--bitstream_cast.sv
@@ -15,10 +15,10 @@
 module top();
   struct packed {logic [7:0] a; logic [7:0] b; logic [15:0] c;} s;
   integer a = integer'(s);
-//^^^^^^^ entity.name.type.integer.sv
+//^^^^^^^ entity.name.type.sv
 //        ^ variable.other.sv
 //          ^ keyword.operator.assignment.sv
-//            ^^^^^^^ entity.name.type.integer.sv
+//            ^^^^^^^ entity.name.type.sv
 //                   ^ punctuation.definition.casting.sv
 //                    ^ punctuation.section.group.begin.sv
 //                     ^ variable.other.sv

--- a/tests/chapter-06/6.5--variable_redeclare.sv
+++ b/tests/chapter-06/6.5--variable_redeclare.sv
@@ -16,7 +16,7 @@
 */
 module top();
   reg v;
-//^^^ entity.name.type.reg.sv
+//^^^ entity.name.type.sv
   wire v;
-//^^^^ entity.name.type.wire.sv
+//^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.6.7--nettype.sv
+++ b/tests/chapter-06/6.6.7--nettype.sv
@@ -15,6 +15,6 @@
 module top();
   nettype real real_net;
 //^^^^^^^ keyword.control.nettype.sv
-//        ^^^^ entity.name.type.real.sv
+//        ^^^^ entity.name.type.sv
 //             ^^^^^^^^ entity.name.type.sv
 endmodule

--- a/tests/chapter-06/6.6.7--nettype_resolution_fn.sv
+++ b/tests/chapter-06/6.6.7--nettype_resolution_fn.sv
@@ -21,7 +21,7 @@ module top();
 
   nettype real real_net with real_sum;
 //^^^^^^^ keyword.control.nettype.sv
-//        ^^^^ entity.name.type.real.sv
+//        ^^^^ entity.name.type.sv
 //             ^^^^^^^^ entity.name.type.sv
 //                      ^^^^ keyword.other.with.sv
 //                           ^^^^^^^^ entity.name.function.sv

--- a/tests/chapter-06/6.6.8--interconnect.sv
+++ b/tests/chapter-06/6.6.8--interconnect.sv
@@ -14,7 +14,7 @@
 */
 module top();
   interconnect bus;
-//^^^^^^^^^^^^ entity.name.type.interconnect.sv
+//^^^^^^^^^^^^ entity.name.type.sv
 
   mod_i m1(bus);
   mod_o m2(bus);

--- a/tests/chapter-06/6.9.1--logic_vector.sv
+++ b/tests/chapter-06/6.9.1--logic_vector.sv
@@ -14,7 +14,7 @@
 */
 module top();
   logic [15:0] a;
-//^^^^^ entity.name.type.logic.sv
+//^^^^^ entity.name.type.sv
 //      ^^^^^^ meta.dimension.sv
 //      ^ punctuation.section.brackets.begin.sv
 //       ^^ constant.numeric.integer.sv

--- a/tests/chapter-06/6.9.2--vector_scalared.sv
+++ b/tests/chapter-06/6.9.2--vector_scalared.sv
@@ -14,6 +14,6 @@
 */
 module top();
   tri1 scalared [15:0] a = 0;
-//^^^^ entity.name.type.tri1.sv
+//^^^^ entity.name.type.sv
 //     ^^^^^^^^ storage.modifier.scalared.sv
 endmodule

--- a/tests/chapter-06/6.9.2--vector_vectored.sv
+++ b/tests/chapter-06/6.9.2--vector_vectored.sv
@@ -14,6 +14,6 @@
 */
 module top();
   tri1 vectored [15:0] a;
-//^^^^ entity.name.type.tri1.sv
+//^^^^ entity.name.type.sv
 //     ^^^^^^^^ storage.modifier.vectored.sv
 endmodule

--- a/tests/chapter-06/6.9.2--vector_vectored_inv.sv
+++ b/tests/chapter-06/6.9.2--vector_vectored_inv.sv
@@ -15,7 +15,7 @@
 */
 module top();
   logic vectored [15:0] a = 0;
-//^^^^^ entity.name.type.logic.sv
+//^^^^^ entity.name.type.sv
 //      ^^^^^^^^ storage.modifier.vectored.sv
   assign a[1] = 1;
 endmodule

--- a/tests/chapter-07/arrays/associative/arguments.sv
+++ b/tests/chapter-07/arrays/associative/arguments.sv
@@ -18,10 +18,10 @@ module top ();
 string arraya[int];
 
 task fun (string arrayb[int]);
-//        ^^^^^^ entity.name.type.string.sv
+//        ^^^^^^ entity.name.type.sv
 //               ^^^^^^ variable.other.sv
 //                     ^^^^^ meta.dimension.sv
-//                      ^^^ entity.name.type.int.sv
+//                      ^^^ entity.name.type.sv
   arrayb[ 1 ] = "d";
   $display(":assert: (('%s' == 'a') and ('%s' == 'd') and ('%s' == 'c'))",
     arrayb[0], arrayb[1], arrayb[2]);

--- a/tests/chapter-07/arrays/associative/integral.sv
+++ b/tests/chapter-07/arrays/associative/integral.sv
@@ -15,6 +15,6 @@
 module top ();
 
 int arr [ integer ];
-//        ^^^^^^^ entity.name.type.integer.sv
+//        ^^^^^^^ entity.name.type.sv
 
 endmodule

--- a/tests/chapter-07/arrays/associative/string.sv
+++ b/tests/chapter-07/arrays/associative/string.sv
@@ -15,6 +15,6 @@
 module top ();
 
 int arr [ string ];
-//        ^^^^^^ entity.name.type.string.sv
+//        ^^^^^^ entity.name.type.sv
 
 endmodule

--- a/tests/chapter-07/structures/packed/basic.sv
+++ b/tests/chapter-07/structures/packed/basic.sv
@@ -19,7 +19,7 @@ module top ();
 //^^^^^^ storage.type.struct.sv
 //       ^^^^^^ storage.modifier.packed.sv
   bit [3:0] lo;
-//^^^ entity.name.type.bit.sv
+//^^^ entity.name.type.sv
 //    ^^^^^ meta.dimension.sv
 //          ^^ variable.other.sv
   bit [3:0] hi;

--- a/tests/chapter-07/unions/tagged/basic.sv
+++ b/tests/chapter-07/unions/tagged/basic.sv
@@ -22,7 +22,7 @@ module top ();
 //^^^^^ storage.type.union.sv
 //      ^^^^^^ storage.modifier.tagged.sv
   void invalid;
-//^^^^ entity.name.type.void.sv
+//^^^^ entity.name.type.sv
   bit [3:0] valid;
 } un;
 

--- a/tests/chapter-08/8.15--super-default-new.sv
+++ b/tests/chapter-08/8.15--super-default-new.sv
@@ -26,7 +26,7 @@ package test_pkg;
     virtual function void print ();
 //  ^^^^^^^ storage.modifier.virtual.sv
 //          ^^^^^^^^ storage.type.function.sv
-//                   ^^^^ entity.name.type.void.sv
+//                   ^^^^ entity.name.type.sv
 //                        ^^^^^ entity.name.function.sv
       $display ("Print");
     endfunction : print

--- a/tests/chapter-08/8.18--var_local.sv
+++ b/tests/chapter-08/8.18--var_local.sv
@@ -16,7 +16,7 @@ module class_tb ();
   class a_cls;
     local int a_loc = 2;
 //  ^^^^^ storage.modifier.local.sv
-//        ^^^ entity.name.type.int.sv
+//        ^^^ entity.name.type.sv
 //            ^^^^^ variable.other.sv
 //                  ^ keyword.operator.assignment.sv
 //                    ^ constant.numeric.integer.sv

--- a/tests/chapter-08/8.18--var_protected.sv
+++ b/tests/chapter-08/8.18--var_protected.sv
@@ -16,7 +16,7 @@ module class_tb ();
   class a_cls;
     protected int a_prot = 2;
 //  ^^^^^^^^^ storage.modifier.protected.sv
-//            ^^^ entity.name.type.int.sv
+//            ^^^ entity.name.type.sv
 //                ^^^^^^ variable.other.sv
 //                       ^ keyword.operator.assignment.sv
 //                         ^ constant.numeric.integer.sv

--- a/tests/chapter-08/8.19--global_constant.sv
+++ b/tests/chapter-08/8.19--global_constant.sv
@@ -16,7 +16,7 @@ module class_tb ();
   class a_cls;
     const int c = 12;
 //  ^^^^^ storage.modifier.const.sv
-//        ^^^ entity.name.type.int.sv
+//        ^^^ entity.name.type.sv
 //            ^ variable.other.sv
 //              ^ keyword.operator.assignment.sv
 //                ^^ constant.numeric.integer.sv

--- a/tests/chapter-08/8.19--instance_constant.sv
+++ b/tests/chapter-08/8.19--instance_constant.sv
@@ -16,7 +16,7 @@ module class_tb ();
   class a_cls;
     const int c;
 //  ^^^^^ storage.modifier.const.sv
-//        ^^^ entity.name.type.int.sv
+//        ^^^ entity.name.type.sv
 //            ^ variable.other.sv
     function new(int val);
       c = 20 * val;

--- a/tests/chapter-08/8.21--abstract_class_inst.sv
+++ b/tests/chapter-08/8.21--abstract_class_inst.sv
@@ -23,7 +23,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^ entity.name.function.sv
 //                                  ^ punctuation.section.group.begin.sv
 //                                   ^ punctuation.section.group.end.sv

--- a/tests/chapter-08/8.26.3--type_access_extends.sv
+++ b/tests/chapter-08/8.26.3--type_access_extends.sv
@@ -16,7 +16,7 @@ module class_tb ();
   interface class ihello;
     typedef int int_t;
 //  ^^^^^^^ keyword.control.typedef.sv
-//          ^^^ entity.name.type.int.sv
+//          ^^^ entity.name.type.sv
 //              ^^^^^ entity.name.type.sv
     pure virtual function void hello(int_t val);
   endclass
@@ -31,7 +31,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^^^^ entity.name.function.sv
 //                                     ^ punctuation.section.group.begin.sv
 //                                      ^^^^^ entity.name.type.sv

--- a/tests/chapter-08/8.26.6.1--name_conflict_resolved.sv
+++ b/tests/chapter-08/8.26.6.1--name_conflict_resolved.sv
@@ -19,7 +19,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^ entity.name.function.sv
   endclass
 
@@ -28,7 +28,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^ entity.name.function.sv
   endclass
 

--- a/tests/chapter-08/8.26.6.2--parameter_type_conflict_unresolved.sv
+++ b/tests/chapter-08/8.26.6.2--parameter_type_conflict_unresolved.sv
@@ -20,7 +20,7 @@ module class_tb ();
 //                     ^^^^ storage.type.type.sv
 //                          ^ entity.name.type.sv
 //                            ^ keyword.operator.assignment.sv
-//                              ^^^^^ entity.name.type.logic.sv
+//                              ^^^^^ entity.name.type.sv
     pure virtual function void fn1(T a);
 //                                 ^ entity.name.type.sv
 //                                   ^ variable.other.sv
@@ -35,7 +35,7 @@ module class_tb ();
 //                     ^^^^ storage.type.type.sv
 //                          ^^^^ entity.name.type.sv
 //                               ^ keyword.operator.assignment.sv
-//                                 ^^^^^ entity.name.type.logic.sv
+//                                 ^^^^^ entity.name.type.sv
 //                                        ^^^^^^^ storage.modifier.extends.sv
 //                                                ^^^ entity.name.type.sv
 //                                                     ^^^^ variable.other.constant.sv

--- a/tests/chapter-08/8.26.6.3--diamond_relationship_parametrized.sv
+++ b/tests/chapter-08/8.26.6.3--diamond_relationship_parametrized.sv
@@ -20,12 +20,12 @@ module class_tb ();
   endclass
 
   interface class ic1 extends ibase#(bit);
-//                                   ^^^ entity.name.type.bit.sv
+//                                   ^^^ entity.name.type.sv
     pure virtual function void fn1();
   endclass
 
   interface class ic2 extends ibase#(string);
-//                                   ^^^^^^ entity.name.type.string.sv
+//                                   ^^^^^^ entity.name.type.sv
     pure virtual function void fn2();
   endclass
 

--- a/tests/chapter-08/8.26.7--partial_implementation.sv
+++ b/tests/chapter-08/8.26.7--partial_implementation.sv
@@ -19,7 +19,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^ entity.name.function.sv
   endclass
 
@@ -31,7 +31,7 @@ module class_tb ();
 //  ^^^^ storage.modifier.pure.sv
 //       ^^^^^^^ storage.modifier.virtual.sv
 //               ^^^^^^^^ storage.type.function.sv
-//                        ^^^^ entity.name.type.void.sv
+//                        ^^^^ entity.name.type.sv
 //                             ^^^^^ entity.name.function.sv
   endclass
 

--- a/tests/chapter-08/8.4--instantiation.sv
+++ b/tests/chapter-08/8.4--instantiation.sv
@@ -18,7 +18,7 @@ module class_tb ();
 //      ^^^^^^^^ entity.name.type.sv
 //              ^ punctuation.terminator.semicolon.sv
     int a;
-//  ^^^ entity.name.type.int.sv
+//  ^^^ entity.name.type.sv
 //      ^ variable.other.sv
   endclass
 //^^^^^^^^ storage.type.class.sv

--- a/tests/chapter-08/8.5--properties.sv
+++ b/tests/chapter-08/8.5--properties.sv
@@ -16,7 +16,7 @@
 module class_tb ();
   class test_cls;
     int a;
-//  ^^^ entity.name.type.int.sv
+//  ^^^ entity.name.type.sv
 //      ^ variable.other.sv
   endclass
 

--- a/tests/chapter-08/8.6--methods.sv
+++ b/tests/chapter-08/8.6--methods.sv
@@ -19,7 +19,7 @@ module class_tb ();
 //  ^^^^ storage.type.task.sv
 //       ^^^^^^^^^^^ entity.name.function.sv
 //                  ^ punctuation.section.group.begin.sv
-//                   ^^^ entity.name.type.int.sv
+//                   ^^^ entity.name.type.sv
 //                       ^^^ variable.other.sv
 //                          ^ punctuation.section.group.end.sv
       $display("test_method");

--- a/tests/chapter-08/8.9--static_properties.sv
+++ b/tests/chapter-08/8.9--static_properties.sv
@@ -16,7 +16,7 @@ module class_tb ();
   class test_cls;
     static int s = 24;
 //  ^^^^^^ storage.modifier.static.sv
-//         ^^^ entity.name.type.int.sv
+//         ^^^ entity.name.type.sv
   endclass
 
   test_cls test_obj0;

--- a/tests/chapter-09/9.3.3--event.sv
+++ b/tests/chapter-09/9.3.3--event.sv
@@ -18,7 +18,7 @@
 
 module block_tb ();
   event ev;
-//^^^^^ entity.name.type.event.sv
+//^^^^^ entity.name.type.sv
   reg [3:0] a = 0;
   initial fork
     begin

--- a/tests/chapter-09/9.7--process_cls_await.sv
+++ b/tests/chapter-09/9.7--process_cls_await.sv
@@ -22,7 +22,7 @@ module process_tb ();
       fork
         automatic int k = i;
 //      ^^^^^^^^^ storage.modifier.automatic.sv
-//                ^^^ entity.name.type.int.sv
+//                ^^^ entity.name.type.sv
         begin
           job[k] = process::self();
 //                 ^^^^^^^ entity.name.namespace.sv

--- a/tests/chapter-10/10.3.1--net-decl-assignment.sv
+++ b/tests/chapter-10/10.3.1--net-decl-assignment.sv
@@ -15,7 +15,7 @@
 module top(input a, input b);
 
 wire w = a & b;
-//<---- entity.name.type.wire.sv
+//<---- entity.name.type.sv
 //   ^ variable.other.sv
 //     ^ keyword.operator.assignment.sv
 //       ^ variable.other.sv

--- a/tests/chapter-10/10.3.2--cont-assignment.sv
+++ b/tests/chapter-10/10.3.2--cont-assignment.sv
@@ -15,7 +15,7 @@
 module top(input a, input b);
 
 wire w;
-//<---- entity.name.type.wire.sv
+//<---- entity.name.type.sv
 //   ^ variable.other.sv
 assign w = a & b;
 //<------ keyword.control.assign.sv

--- a/tests/chapter-10/10.3.3--cont-assignment-net-delay.sv
+++ b/tests/chapter-10/10.3.3--cont-assignment-net-delay.sv
@@ -15,7 +15,7 @@
 module top(input a, input b);
 
 wire #10 w;
-//<---- entity.name.type.wire.sv
+//<---- entity.name.type.sv
 //   ^ punctuation.definition.delay.sv
 //    ^^ constant.numeric.integer.sv
 //       ^ variable.other.sv

--- a/tests/chapter-10/10.4.1--blocking-assignment.sv
+++ b/tests/chapter-10/10.4.1--blocking-assignment.sv
@@ -16,12 +16,12 @@
 module top();
 
 logic a = 3;
-//<----- entity.name.type.logic.sv
+//<----- entity.name.type.sv
 //    ^ variable.other.sv
 //      ^ keyword.operator.assignment.sv
 //        ^ constant.numeric.integer.sv
 logic b = 2;
-//<----- entity.name.type.logic.sv
+//<----- entity.name.type.sv
 //    ^ variable.other.sv
 //      ^ keyword.operator.assignment.sv
 //        ^ constant.numeric.integer.sv

--- a/tests/chapter-11/11.4.14.2--reorder_stream_byte-sim.sv
+++ b/tests/chapter-11/11.4.14.2--reorder_stream_byte-sim.sv
@@ -22,7 +22,7 @@ initial begin
   b = {<< byte {a}};
 //    ^^^^^^^^^^^^^ meta.concatenation.sv
 //     ^^ keyword.operator.stream.sv
-//        ^^^^ entity.name.type.byte.sv
+//        ^^^^ entity.name.type.sv
 //             ^^^ meta.concatenation.sv meta.concatenation.sv
   $display(":assert: (0x44434241 == 0x%x)", b);
 end

--- a/tests/chapter-11/11.4.14.2--reorder_stream_byte.sv
+++ b/tests/chapter-11/11.4.14.2--reorder_stream_byte.sv
@@ -21,7 +21,7 @@ initial begin
   b = {<< byte {a}};
 //    ^^^^^^^^^^^^^ meta.concatenation.sv
 //     ^^ keyword.operator.stream.sv
-//        ^^^^ entity.name.type.byte.sv
+//        ^^^^ entity.name.type.sv
 //             ^^^ meta.concatenation.sv meta.concatenation.sv
 end
 

--- a/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
+++ b/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
@@ -29,10 +29,10 @@ typedef union tagged {
 //      ^^^^^ storage.type.union.sv
 //            ^^^^^^ storage.modifier.tagged.sv
   void Invalid;
-//^^^^ entity.name.type.void.sv
+//^^^^ entity.name.type.sv
 //     ^^^^^^^ variable.other.constant.sv
   int Valid;
-//^^^ entity.name.type.int.sv
+//^^^ entity.name.type.sv
 //    ^^^^^ variable.other.constant.sv
 } u_int;
 

--- a/tests/chapter-12/12.7.1--for.sv
+++ b/tests/chapter-12/12.7.1--for.sv
@@ -17,7 +17,7 @@ module for_tb ();
     for (int i = 0; i < 256; i++)
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.for.sv
 //  ^^^ keyword.control.for.sv
-//       ^^^ entity.name.type.int.sv
+//       ^^^ entity.name.type.sv
 //           ^ variable.other.sv
 //             ^ keyword.operator.assignment.sv
 //               ^ constant.numeric.integer.sv

--- a/tests/chapter-13/13.4--function.sv
+++ b/tests/chapter-13/13.4--function.sv
@@ -17,10 +17,10 @@ module top();
 
   function int test(int val);
 //^^^^^^^^ storage.type.function.sv
-//         ^^^ entity.name.type.int.sv
+//         ^^^ entity.name.type.sv
 //             ^^^^ entity.name.function.sv
 //                 ^ punctuation.section.group.begin.sv
-//                  ^^^ entity.name.type.int.sv
+//                  ^^^ entity.name.type.sv
 //                      ^^^ variable.other.sv
 //                         ^ punctuation.section.group.end.sv
     return val + 1;

--- a/tests/chapter-13/13.4.1--function-return-assignment.sv
+++ b/tests/chapter-13/13.4.1--function-return-assignment.sv
@@ -17,7 +17,7 @@ module top();
 
   function int add(int a, int b);
 //^^^^^^^^ storage.type.function.sv
-//         ^^^ entity.name.type.int.sv
+//         ^^^ entity.name.type.sv
 //             ^^^ entity.name.function.sv
     add = a + b;
 //  ^^^ variable.other.sv

--- a/tests/chapter-13/13.4.1--function-void-return.sv
+++ b/tests/chapter-13/13.4.1--function-void-return.sv
@@ -17,7 +17,7 @@
 module top();
 
   function void add(int a, int b);
-//         ^^^^ entity.name.type.void.sv
+//         ^^^^ entity.name.type.sv
     $display("%d+%d=", a, b);
     return a + b;
   endfunction

--- a/tests/chapter-15/15.4--mailbox-blocking.sv
+++ b/tests/chapter-15/15.4--mailbox-blocking.sv
@@ -19,7 +19,7 @@ module top();
 //^^^^^^^ entity.name.type.sv
 //        ^ punctuation.definition.parameter-assignment-or-delay.sv
 //         ^ punctuation.section.group.begin.sv
-//          ^^^^^^ entity.name.type.string.sv
+//          ^^^^^^ entity.name.type.sv
 //                ^ punctuation.section.group.end.sv
 //                  ^ variable.other.sv
 //                   ^ punctuation.terminator.semicolon.sv

--- a/tests/chapter-16/16.10--property-local-var-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-fail.sv
@@ -62,7 +62,7 @@ module top();
 
     property prop;
         int x;
-//      ^^^ entity.name.type.int.sv
+//      ^^^ entity.name.type.sv
 //          ^ variable.other.sv
         @(posedge clk) (valid, x = in) |-> ##4 (out == x + 3);
     endproperty

--- a/tests/chapter-16/16.10--sequence-local-var-fail.sv
+++ b/tests/chapter-16/16.10--sequence-local-var-fail.sv
@@ -62,7 +62,7 @@ module top();
 
     sequence seq;
         int x;
-//      ^^^ entity.name.type.int.sv
+//      ^^^ entity.name.type.sv
 //          ^ variable.other.sv
         @(posedge clk) (valid, x = in) ##4 (out == x + 3);
     endsequence

--- a/tests/chapter-18/18.17.7--value-passing-between-productions_0.sv
+++ b/tests/chapter-18/18.17.7--value-passing-between-productions_0.sv
@@ -27,7 +27,7 @@ function int F();
       second : add(5);
       third : add(2);
       void add(int y) : { x = x + y; };
-//    ^^^^ entity.name.type.void.sv
+//    ^^^^ entity.name.type.sv
 //         ^^^ entity.name.function.sv
     endsequence
     return x;

--- a/tests/chapter-18/18.4.1--rand-modifier.sv
+++ b/tests/chapter-18/18.4.1--rand-modifier.sv
@@ -16,6 +16,6 @@
 class a;
     rand int b;
 //  ^^^^ storage.modifier.rand.sv
-//       ^^^ entity.name.type.int.sv
+//       ^^^ entity.name.type.sv
 //           ^ variable.other.sv
 endclass

--- a/tests/chapter-18/18.4.2--randc-modifier.sv
+++ b/tests/chapter-18/18.4.2--randc-modifier.sv
@@ -16,6 +16,6 @@
 class a;
     randc int b;
 //  ^^^^^ storage.modifier.randc.sv
-//        ^^^ entity.name.type.int.sv
+//        ^^^ entity.name.type.sv
 //            ^ variable.other.sv
 endclass

--- a/tests/chapter-20/20.6--typename_type.sv
+++ b/tests/chapter-20/20.6--typename_type.sv
@@ -19,7 +19,7 @@ module top();
 initial begin
   $display(":assert: ('%s' == 'logic')", $typename(logic));
 //                                       ^^^^^^^^^ entity.name.function.sv
-//                                                 ^^^^^ entity.name.type.logic.sv
+//                                                 ^^^^^ entity.name.type.sv
 end
 
 endmodule

--- a/tests/chapter-22/22.8--default_nettype-redefinition.sv
+++ b/tests/chapter-22/22.8--default_nettype-redefinition.sv
@@ -15,34 +15,34 @@
 */
 `default_nettype wire
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.wire.sv
+//               ^^^^ entity.name.type.sv
 `default_nettype tri
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^ entity.name.type.tri.sv
+//               ^^^ entity.name.type.sv
 `default_nettype tri0
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.tri0.sv
+//               ^^^^ entity.name.type.sv
 `default_nettype tri1
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.tri1.sv
+//               ^^^^ entity.name.type.sv
 `default_nettype wand
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.wand.sv
+//               ^^^^ entity.name.type.sv
 `default_nettype triand
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^^^ entity.name.type.triand.sv
+//               ^^^^^^ entity.name.type.sv
 `default_nettype wor
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^ entity.name.type.wor.sv
+//               ^^^ entity.name.type.sv
 `default_nettype trior
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^^ entity.name.type.trior.sv
+//               ^^^^^ entity.name.type.sv
 `default_nettype trireg
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^^^ entity.name.type.trireg.sv
+//               ^^^^^^ entity.name.type.sv
 `default_nettype uwire
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^^ entity.name.type.uwire.sv
+//               ^^^^^ entity.name.type.sv
 `default_nettype none
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.none.sv
+//               ^^^^ entity.name.type.sv

--- a/tests/chapter-22/22.8--default_nettype.sv
+++ b/tests/chapter-22/22.8--default_nettype.sv
@@ -15,4 +15,4 @@
 */
 `default_nettype wire
 //<---------------- keyword.control.default-nettype.sv
-//               ^^^^ entity.name.type.wire.sv
+//               ^^^^ entity.name.type.sv

--- a/tests/chapter-22/misc.sv
+++ b/tests/chapter-22/misc.sv
@@ -22,12 +22,12 @@
 
 `define MACRO_FUNC(name) \
   logic \escapeIdentifier ;
-//^^^^^ entity.name.type.logic.sv
+//^^^^^ entity.name.type.sv
 //      ^^^^^^^^^^^^^^^^^ variable.other.sv
 
 `define MACRO_FUNC(name) \
   logic \escapeIdentifier``name`` ;
-//^^^^^ entity.name.type.logic.sv
+//^^^^^ entity.name.type.sv
 //      ^^^^^^^^^^^^^^^^^ variable.other.sv
 //                       ^^ constant.character.escape.sv
 //                         ^^^^ variable.other.sv

--- a/tests/chapter-24/24.3--program.sv
+++ b/tests/chapter-24/24.3--program.sv
@@ -18,11 +18,11 @@
 //        ^^^^ entity.name.type.sv
 //            ^ punctuation.section.group.begin.sv
 //             ^^^^^ storage.modifier.input.sv
-//                   ^^^^ entity.name.type.wire.sv
+//                   ^^^^ entity.name.type.sv
 //                        ^ variable.other.sv
 //                         ^ punctuation.separator.comma.sv
 //                           ^^^^^ storage.modifier.input.sv
-//                                 ^^^^ entity.name.type.wire.sv
+//                                 ^^^^ entity.name.type.sv
 //                                      ^ variable.other.sv
 //                                       ^ punctuation.section.group.end.sv
 //                                        ^ punctuation.terminator.semicolon.sv

--- a/tests/chapter-25/25.3--interface.sv
+++ b/tests/chapter-25/25.3--interface.sv
@@ -19,7 +19,7 @@
 //          ^^^^^^^^ entity.name.type.sv
 //                  ^ punctuation.terminator.semicolon.sv
     logic test_pad;
-//  ^^^^^ entity.name.type.logic.sv
+//  ^^^^^ entity.name.type.sv
 //        ^^^^^^^^ variable.other.sv
 //                ^ punctuation.terminator.semicolon.sv
   endinterface: test_bus

--- a/tests/chapter-25/25.4--interface-port.sv
+++ b/tests/chapter-25/25.4--interface-port.sv
@@ -2,7 +2,7 @@
 
 interface simple_bus (input logic clk); // Define the interface
 //                    ^^^^^ storage.modifier.input.sv
-//                          ^^^^^ entity.name.type.logic.sv
+//                          ^^^^^ entity.name.type.sv
 //                                ^^^ variable.other.sv
   logic req, gnt;
   logic [7:0] addr, data;

--- a/tests/chapter-25/25.7--interface-tf.sv
+++ b/tests/chapter-25/25.7--interface-tf.sv
@@ -138,7 +138,7 @@ interface simple_bus (input logic clk); // Define the interface
 //         ^^^^ storage.type.task.sv
 //              ^^^^ entity.name.function.sv
 //                   ^^^^^ storage.modifier.input.sv
-//                         ^^^^^ entity.name.type.logic.sv
+//                         ^^^^^ entity.name.type.sv
 //                               ^^^^^ meta.dimension.sv
     task Write(input logic [7:0] waddr));
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.task-prototype.sv
@@ -285,7 +285,7 @@ interface Test;
   extern function void foo();
 //^^^^^^ storage.modifier.extern.sv
 //       ^^^^^^^^ storage.type.function.sv
-//                ^^^^ entity.name.type.void.sv
+//                ^^^^ entity.name.type.sv
 //                     ^^^ entity.name.function.sv
 
   extern function my_type foo();


### PR DESCRIPTION
## Summary

- Standardize all specific type scopes (`entity.name.type.int.sv`, `entity.name.type.logic.sv`, etc.) to generic `entity.name.type.sv`
- Simplifies the grammar and provides consistent highlighting for all built-in types
- Updated 15 grammar patterns and 79 test files

## Rationale

The codebase had inconsistent type scope naming:
- 61 generic scopes (`entity.name.type.sv`)
- 14 specific scopes (`entity.name.type.$1.sv`)

Since most were already generic and the specific type info provides minimal practical benefit for syntax highlighting, this standardizes on the simpler generic format.

## Test plan

- [x] All 369 tests pass
- [x] Verified grammar builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)