### PR TITLE
Release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.0.3] - 2025-12-19
+
+### Fixed
+
+- Fix `if` not highlighted as keyword after case item colon
+- Fix `return` incorrectly highlighted as type name
+- Fix constraint `if-else` with braces not highlighted correctly
+- Fix hierarchical identifiers in `solve...before` and `soft` constraints
+- Support `inside` and `tagged` keywords in constant expressions (parameter/localparam)
+
+### Changed
+
+- Standardize type scopes to generic `entity.name.type.sv`
+
 ## [1.0.2] - 2024-10-26
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,5 +120,15 @@ Use branch + PR workflow with these prefixes:
 - `bugfix/` - Fixes for incorrect highlighting
 - `docs/` - Documentation changes
 - `chore/` - Dependencies, CI, tooling updates
+- `release/` - Version releases
 
-Open a PR, let CI pass, then merge to main.
+Open a PR, let CI pass, then merge to main. Direct push to main is disabled.
+
+## Release Workflow
+
+1. Update version in `package.json`
+2. Run `npm install` to sync `package-lock.json`
+3. Update `CHANGELOG.md` with release notes
+4. Create branch (`release/v1.x.x`) and PR
+5. After merge, create git tag: `git tag v1.x.x && git push origin v1.x.x`
+6. Publish: `npm run publish`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- Bump version to 1.0.3
- Update CHANGELOG with bug fixes since v1.0.2
- Add release workflow documentation to CLAUDE.md

## Changes since v1.0.2
- Fix `if` not highlighted as keyword after case item colon
- Fix `return` incorrectly highlighted as type name
- Fix constraint `if-else` with braces not highlighted correctly
- Fix hierarchical identifiers in `solve...before` and `soft` constraints
- Support `inside` and `tagged` keywords in constant expressions
- Standardize type scopes to generic `entity.name.type.sv`

🤖 Generated with [Claude Code](https://claude.ai/code)