### PR TITLE
Add triple-quoted raw string literals (IEEE 1800-2023)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "package": "npm run build && vsce package",
     "publish": "npm run package && vsce publish",
     "test": "npm run build && vscode-tmgrammar-test -g syntaxes/systemverilog.tmLanguage.json \"tests/**/*.sv\"",
+    "test:only": "npm run build && vscode-tmgrammar-test -g syntaxes/systemverilog.tmLanguage.json",
     "test-watch": "nodemon --watch src --watch syntaxes --watch tests -e ts,yaml,sv --exec \"npm run test\""
   },
   "contributes": {

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6685,6 +6685,7 @@ repository:
       - include: "#expression"
   primary-literal:
     patterns:
+      - include: "#triple-quoted-string-literal"
       - include: "#string-literal"
       - include: "#time-literal"
       - include: "#unbased-unsized-literal"
@@ -6843,6 +6844,14 @@ repository:
     patterns:
       - include: "#constant-expression"
   # A.8.8 Strings
+  triple-quoted-string-literal:
+    name: string.quoted.triple.sv
+    begin: '"""'
+    end: '"""'
+    beginCaptures:
+      "0": { name: punctuation.definition.string.begin.sv }
+    endCaptures:
+      "0": { name: punctuation.definition.string.end.sv }
   string-literal:
     name: string.quoted.double.sv
     begin: \"
@@ -7458,6 +7467,7 @@ repository:
           - include: "#pragma-expression"
       - include: "#number"
       - include: "#unary-operator"
+      - include: "#triple-quoted-string-literal"
       - include: "#string-literal"
       - include: "#simple-identifier"
   macro-line:

--- a/tests/chapter-05/5.9--triple-quoted-string_0.sv
+++ b/tests/chapter-05/5.9--triple-quoted-string_0.sv
@@ -1,0 +1,41 @@
+// SYNTAX TEST "source-text.sv"
+
+module top();
+
+  initial begin
+    // Basic triple-quoted string
+    $display("""hello world""");
+//           ^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+//           ^^^ punctuation.definition.string.begin.sv
+//                         ^^^ punctuation.definition.string.end.sv
+
+    // Inner double quotes
+    $display("""say "hello" please""");
+//           ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+//           ^^^ punctuation.definition.string.begin.sv
+//                                ^^^ punctuation.definition.string.end.sv
+
+    // Inner consecutive double quotes
+    $display("""he said ""wow"" """);
+//           ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+//           ^^^ punctuation.definition.string.begin.sv
+//                              ^^^ punctuation.definition.string.end.sv
+
+    // Backslashes are literal (no escape processing)
+    $display("""backslash: \n and \t""");
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+//                         ^^ -constant.character.escape.sv
+//                                  ^^^ punctuation.definition.string.end.sv
+
+    // Empty triple-quoted string
+    $display("""""");
+//           ^^^^^^ string.quoted.triple.sv
+//           ^^^ punctuation.definition.string.begin.sv
+//              ^^^ punctuation.definition.string.end.sv
+
+    // Regular string still works
+    $display("normal string");
+//           ^^^^^^^^^^^^^^^ string.quoted.double.sv
+  end
+
+endmodule

--- a/tests/chapter-05/5.9--triple-quoted-string_1.sv
+++ b/tests/chapter-05/5.9--triple-quoted-string_1.sv
@@ -1,0 +1,32 @@
+// SYNTAX TEST "source-text.sv"
+
+module top();
+
+  initial begin
+    // Multi-line triple-quoted string
+    $display("""
+//           ^^^ punctuation.definition.string.begin.sv
+      This is a multi-line
+//    ^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+      raw string literal.
+//    ^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+    """);
+//  ^^^ punctuation.definition.string.end.sv
+
+    // Multi-line with embedded quotes
+    $display("""
+      She said "hello"
+//    ^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+      and he said "goodbye"
+//    ^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.sv
+    """);
+
+    // Multi-line with backslashes (literal)
+    $display("""
+      path: C:\Users\test
+//           ^^^^^^^^^^^^^ string.quoted.triple.sv
+//                ^ -constant.character.escape.sv
+    """);
+  end
+
+endmodule


### PR DESCRIPTION
## Summary

- Add grammar support for triple-quoted raw string literals (`"""..."""`) introduced in IEEE 1800-2023
- Raw strings have no escape sequence processing — backslashes and quotes are literal
- `triple-quoted-string-literal` rule is matched before `string-literal` in both `primary-literal` and `pragma-value` contexts to prevent `"""` from being parsed as `""` + `"`
- Add `test:only` npm script for selective test runs: `npm run test:only -- "tests/path/*.sv"`

🤖 Generated with [Claude Code](https://claude.ai/code)