### PR TITLE
Fix bracket colorization inside escaped identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       {
         "language": "systemverilog",
         "scopeName": "source-text.sv",
-        "path": "./syntaxes/systemverilog.tmLanguage.json"
+        "path": "./syntaxes/systemverilog.tmLanguage.json",
+        "unbalancedBracketScopes": ["variable.other.sv"]
       }
     ],
     "languages": [


### PR DESCRIPTION
## Summary

- Add `unbalancedBracketScopes: ["variable.other.sv"]` to the grammar entry in `package.json` so VS Code's bracket pair colorizer skips brackets inside escaped identifiers like `\(xxx)`, `\{a,b}`, or `\a*(b+c)`
- No grammar changes needed — the escaped identifier rule already tokenizes these correctly as `variable.other.sv`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)