### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-02-23
+
+### Added
+
+- Add triple-quoted raw string literals (IEEE 1800-2023)
+
+### Fixed
+
+- Fix bracket colorization inside escaped identifiers
+
 ## [1.0.3] - 2025-12-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Bump version to 1.1.0
- Update CHANGELOG with new release notes

### Added
- Triple-quoted raw string literals (IEEE 1800-2023)

### Fixed
- Bracket colorization inside escaped identifiers

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)