### PR TITLE
Fix with clause on array methods in statement position

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -513,7 +513,7 @@ repository:
                   - include: "#dynamic-array-new"
                   - include: "#class-new"
       - name: meta.data-declaration-or-module-instantiation.sv
-        begin: (${identifierNotKeyword})\s*(?=${identifier}\s*\()
+        begin: (${identifierNotKeyword})\s*(?=${identifierNotKeyword}\s*\()
         end: (?=\;)|${bracketsFailSafe}
         beginCaptures:
           "1": { name: entity.name.type.sv }
@@ -3846,7 +3846,7 @@ repository:
           - include: "#hierarchical-instance"
           - include: "#comma"
       - name: meta.module-instantiation.sv
-        begin: (${identifierNotKeyword})\s*(?=${identifier}\s*\()
+        begin: (${identifierNotKeyword})\s*(?=${identifierNotKeyword}\s*\()
         end: (?=\;)|${bracketsFailSafe}
         beginCaptures:
           "1": { name: entity.name.type.sv }

--- a/tests/chapter-07/arrays/unpacked/ordering-methods/sort-with.sv
+++ b/tests/chapter-07/arrays/unpacked/ordering-methods/sort-with.sv
@@ -1,0 +1,28 @@
+// SYNTAX TEST "source-text.sv"
+
+// Array ordering method `sort`/`rsort` with a `with` clause (IEEE 1800 7.12.2).
+// The `with` clause must be highlighted correctly even when the call appears
+// as a standalone statement (not on the right-hand side of an assignment).
+
+module top ();
+
+int a_key[];
+
+initial begin
+  a_key.sort with (10 - item);
+//      ^^^^ entity.name.function.sv
+//           ^^^^ keyword.other.with.sv
+//                ^ punctuation.section.group.begin.sv
+//                 ^^ constant.numeric.integer.sv
+//                    ^ keyword.operator.binary.sv
+//                      ^^^^ variable.other.sv
+//                          ^ punctuation.section.group.end.sv
+  a_key.rsort with (item);
+//      ^^^^^ entity.name.function.sv
+//            ^^^^ keyword.other.with.sv
+//                 ^ punctuation.section.group.begin.sv
+//                  ^^^^ variable.other.sv
+//                      ^ punctuation.section.group.end.sv
+end
+
+endmodule


### PR DESCRIPTION
## Summary

- `var.method with (...)` as a standalone statement was misparsed as a module
  instantiation, so `sort`/`rsort`/`find` were highlighted as a type and the
  `with` keyword lost its scope
- Require a non-keyword instance name in the module-instantiation lookahead so
  `with` no longer triggers the instantiation rule
- Add a test for `sort`/`rsort` with a `with` clause as standalone statements

🤖 Generated with [Claude Code](https://claude.ai/code)