### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-19
+
+### Fixed
+
+- Fix `with` clause on array methods highlighted as module instantiation in statement position
+
 ## [1.1.0] - 2026-02-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -4508,6 +4508,7 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4552,8 +4553,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
       "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Bump version to 1.1.1
- Update CHANGELOG with new release notes

### Fixed
- `with` clause on array methods highlighted as module instantiation in statement position

🤖 Generated with [Claude Code](https://claude.ai/code)