### PR TITLE
Exclude dev and meta files from published package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,13 @@ out/test/**
 **/.vscode
 **/.git
 **/.github
+.claude/**
+.nvmrc
+
+AGENTS.md
+CLAUDE.md
+CLAUDE.local.md
+docs/**
 **/*.yml
 **/*.yaml
 **/node_modules/**


### PR DESCRIPTION
## Summary

- The packaged `.vsix` was shipping development and meta files to the Marketplace, including `.claude/settings.local.json`, `CLAUDE.local.md` (personal notes), `CLAUDE.md`/`AGENTS.md`, `.nvmrc`, and `docs/COVERAGE.md`
- Add these to `.vscodeignore` so the published package contains only the grammar, language configuration, and user-facing docs (README/CHANGELOG/LICENSE)

After this change `vsce ls` lists only: `package.json`, `language-configuration.json`, `README.md`, `LICENSE`, `CHANGELOG.md`, `syntaxes/systemverilog.tmLanguage.json`, `assets/icon.png`, `assets/showcase.gif`.

🤖 Generated with [Claude Code](https://claude.ai/code)