### PR TITLE
Fix casting type keywords not highlighted in cast expressions

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6733,6 +6733,18 @@ repository:
       - include: "#dimension"
       - include: "#dot"
       - include: "#member-identifier"
+  casting-type:
+    patterns:
+      # casting_type ::= simple_type | signing | string | const | void
+      - include: "#integer-type"
+      - include: "#non-integer-type"
+      - include: "#signing"
+      - match: \b(void|string)\b\s*
+        captures:
+          "1": { name: entity.name.type.sv }
+      - match: \b(const)\b\s*
+        captures:
+          "1": { name: storage.modifier.const.sv }
   constant-cast:
     patterns:
       - include: "#casting-type"

--- a/tests/chapter-06/6.24.1--cast_op_types.sv
+++ b/tests/chapter-06/6.24.1--cast_op_types.sv
@@ -1,0 +1,52 @@
+// SYNTAX TEST "source-text.sv"
+
+// Cast operator with the various casting types (IEEE 1800 6.24.1, A.2.2.1):
+//   casting_type ::= simple_type | constant_primary | signing | string | const
+// Every casting type keyword must be highlighted, not just the integer atom
+// types. `void'(...)` in statement position must also be highlighted.
+
+module top ();
+
+initial begin
+  a = bit'(x);
+//    ^^^ entity.name.type.sv
+//       ^ punctuation.definition.casting.sv
+  a = logic'(x);
+//    ^^^^^ entity.name.type.sv
+//         ^ punctuation.definition.casting.sv
+  a = reg'(x);
+//    ^^^ entity.name.type.sv
+//       ^ punctuation.definition.casting.sv
+  a = int'(x);
+//    ^^^ entity.name.type.sv
+//       ^ punctuation.definition.casting.sv
+  a = real'(x);
+//    ^^^^ entity.name.type.sv
+//        ^ punctuation.definition.casting.sv
+  a = shortreal'(x);
+//    ^^^^^^^^^ entity.name.type.sv
+//             ^ punctuation.definition.casting.sv
+  a = realtime'(x);
+//    ^^^^^^^^ entity.name.type.sv
+//            ^ punctuation.definition.casting.sv
+  a = string'(x);
+//    ^^^^^^ entity.name.type.sv
+//          ^ punctuation.definition.casting.sv
+  a = unsigned'(x);
+//    ^^^^^^^^ storage.modifier.unsigned.sv
+//            ^ punctuation.definition.casting.sv
+  a = signed'(x);
+//    ^^^^^^ storage.modifier.signed.sv
+//          ^ punctuation.definition.casting.sv
+  a = const'(x);
+//    ^^^^^ storage.modifier.const.sv
+//         ^ punctuation.definition.casting.sv
+  void'(x);
+//^^^^ entity.name.type.sv
+//    ^ punctuation.definition.casting.sv
+  void'(f(a, b));
+//^^^^ entity.name.type.sv
+//    ^ punctuation.definition.casting.sv
+end
+
+endmodule


### PR DESCRIPTION
## Summary

- Cast expressions using data-type keywords (`void'(...)`, `bit'(...)`, `logic'(...)`, `real'(...)`, `string'(...)`, `signed'(...)`, `const'(...)`, etc.) did not highlight the casting type
- Root cause: `cast`/`constant-cast` included `#casting-type`, but that repository rule was never defined (a dangling include). Only integer atom types (`int`, `byte`, ...) were colored, and only incidentally via the assignment-pattern rule
- Define `casting-type` by reusing the existing `#integer-type`, `#non-integer-type`, and `#signing` rules, plus `void`/`string`/`const`
- Add `tests/chapter-06/6.24.1--cast_op_types.sv` covering every casting type keyword, including `void'(...)` in statement position

🤖 Generated with [Claude Code](https://claude.ai/code)