### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-08
+
+### Fixed
+
+- Fix casting type keywords (`void`, `bit`, `logic`, `real`, `string`, `signed`, etc.) not highlighted in cast expressions
+
 ## [1.1.1] - 2026-06-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Bump version to 1.1.2
- Add CHANGELOG entry for the casting type keyword highlighting fix (#22)

🤖 Generated with [Claude Code](https://claude.ai/code)