### PR TITLE
Fix subroutine call not highlighted after a condition's closing paren

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6275,7 +6275,7 @@ repository:
       - include: "#function-subroutine-call"
   tf-call:
     name: meta.tf-call.sv
-    begin: (?<!(?:${simpleIdentifier}|\))\s+)(${functionIdentifier}|\bnew\b)\s*(\()\s*
+    begin: (?<!(?:${simpleIdentifier})\s+)(${functionIdentifier}|\bnew\b)\s*(\()\s*
     end: (\))\s*|${bracketsFailSafe}
     beginCaptures:
       "1": { name: entity.name.function.sv }

--- a/tests/chapter-12/misc.sv
+++ b/tests/chapter-12/misc.sv
@@ -23,4 +23,22 @@ module test;
 //             ^^^^^^ keyword.control.return.sv
     endcase
   endfunction
+
+  // Subroutine call as the single-statement body of a control-flow statement,
+  // i.e. immediately after the closing paren of the condition.
+  initial begin
+    if (flag) do_thing();
+//            ^^^^^^^^ entity.name.function.sv
+    else do_other();
+//       ^^^^^^^^ entity.name.function.sv
+    while (flag) do_thing();
+//               ^^^^^^^^ entity.name.function.sv
+    foreach (arr[i]) do_thing();
+//                   ^^^^^^^^ entity.name.function.sv
+    repeat (3) do_thing();
+//             ^^^^^^^^ entity.name.function.sv
+  end
+
+  always @(posedge clk) do_thing();
+//                      ^^^^^^^^ entity.name.function.sv
 endmodule


### PR DESCRIPTION
## Summary

- A subroutine call immediately after a condition's closing paren (`if (cond) func();`) was not highlighted — the function name got no scope and `()` was scoped as a plain grouping paren
- Root cause: `tf-call` began with a `(?<!(?:identifier|\))\s+)` lookbehind. The `\)` alternative was meant to keep `mod #(.W(8)) u_inst (...)` from matching as a call, but `if (cond) func(` has the same shape and got blocked too
- The `\)` alternative turned out to be redundant: `module-instantiation` already claims the parameterized instantiation before `tf-call` is tried, so dropping it fixes the call without regressing instantiations
- Also affected `while`, `for`, `foreach`, `repeat`, and `always @(...)` with a single-statement subroutine call body
- Add coverage in `tests/chapter-12/misc.sv`

🤖 Generated with [Claude Code](https://claude.ai/code)