### PR TITLE
Fix token-paste `` breaking highlighting on uppercase macro args

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6916,7 +6916,7 @@ repository:
         name: variable.other.block.sv
         patterns:
             - match: \`\`
-              name: constant.character.escape.sv
+              name: keyword.operator.macro-concatenation.sv
   bin-identifier:
     patterns:
       - include: "#identifier"
@@ -7059,7 +7059,7 @@ repository:
             name: variable.other.sv
             patterns:
                 - match: \`\`
-                  name: constant.character.escape.sv
+                  name: keyword.operator.macro-concatenation.sv
   index-variable-identifier:
     patterns:
       - include: "#identifier"
@@ -7245,7 +7245,7 @@ repository:
             name: variable.other.sv
             patterns:
                 - match: \`\`
-                  name: constant.character.escape.sv
+                  name: keyword.operator.macro-concatenation.sv
   # Compiler directives
   compiler-directive:
     patterns:
@@ -7351,7 +7351,7 @@ repository:
             name: variable.other.sv
             patterns:
               - match: \`\`
-                name: constant.character.escape.sv
+                name: keyword.operator.macro-concatenation.sv
       - include: "#attribute-instance"
       - include: "#module-item"
       - include: "#interface-item"
@@ -7374,6 +7374,14 @@ repository:
       - include: "#expression"
   text-macro-usage:
     patterns:
+      # Token-paste operator `` and the fragment it pastes on. Consume both
+      # before a lone backtick can start a bogus macro reference, e.g.
+      # PREFIX``_bus. The fragment can't reuse ${simpleIdentifier} because that
+      # rejects a leading backtick, which would leave the suffix unhighlighted.
+      - match: (\`\`)([a-zA-Z_][a-zA-Z0-9_\$]*)?
+        captures:
+          "1": { name: keyword.operator.macro-concatenation.sv }
+          "2": { name: variable.other.sv }
       # Macro function
       - begin: (${macro})\s*(\()\s*
         end: (\))\s*|${bracketsFailSafe}

--- a/tests/chapter-22/22.5.1--define-expansion_26.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_26.sv
@@ -14,7 +14,7 @@
 :type: preprocessing
 */
 `define append(f) f``_master
-//                 ^^ constant.character.escape.sv
+//                 ^^ keyword.operator.macro-concatenation.sv
 module top ();
 initial $display(`append(clock));
 endmodule

--- a/tests/chapter-22/misc.sv
+++ b/tests/chapter-22/misc.sv
@@ -29,9 +29,9 @@
   logic \escapeIdentifier``name`` ;
 //^^^^^ entity.name.type.sv
 //      ^^^^^^^^^^^^^^^^^ variable.other.sv
-//                       ^^ constant.character.escape.sv
+//                       ^^ keyword.operator.macro-concatenation.sv
 //                         ^^^^ variable.other.sv
-//                             ^^ constant.character.escape.sv
+//                             ^^ keyword.operator.macro-concatenation.sv
 
 `define msg(x,y) `"x: `\`"y`\`"`"
 //               ^^ constant.character.escape.sv
@@ -47,3 +47,13 @@
 
 `define MY_KEYWORD posedge
 //                 ^^^^^^^ keyword.other.posedge.sv
+
+// Token paste `` on an uppercase macro argument, in an expression. Both the
+// operator and the pasted suffix must be highlighted (no bogus macro ref).
+`define TIE(NAME) assign NAME``_q = NAME``_d;
+//                       ^^^^ variable.other.sv
+//                           ^^ keyword.operator.macro-concatenation.sv
+//                             ^^ variable.other.sv
+//                                  ^^^^ variable.other.constant.sv
+//                                      ^^ keyword.operator.macro-concatenation.sv
+//                                        ^^ variable.other.sv


### PR DESCRIPTION
## Summary

- The token-paste operator ``` `` ``` inside a macro (e.g. `` `define TIE(NAME) assign NAME``_q = NAME``_d; ``) broke highlighting when the pasted identifier was uppercase
- Root cause: an uppercase arg matches the "parameter guess" rule whose character class excludes backticks, so it consumed only `NAME` and left a lone backtick to start a bogus macro reference (`` `_d ``), corrupting the rest of the line. Lowercase args happened to work because their identifier rule includes backticks in the class
- Handle ``` `` ``` in `text-macro-usage` before a lone backtick can be read as a macro, and highlight the pasted suffix (which `${simpleIdentifier}` rejects because of its leading-backtick lookbehind)
- Scope ``` `` ``` as `keyword.operator.macro-concatenation` instead of `constant.character.escape`, and apply it consistently across the identifier-paste rules (LHS and RHS now match). The ``` `` ``` inside `` `"..." `` macro strings stays `constant.character.escape`
- Update the two existing tests that encoded the old escape scope, and add a case in `tests/chapter-22/misc.sv`

🤖 Generated with [Claude Code](https://claude.ai/code)