### PR TITLE
Bump version to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-07-18
+
+### Fixed
+
+- Fix the token-paste operator breaking highlighting on uppercase macro arguments, e.g. ``` NAME``_q ```
+
 ## [1.1.3] - 2026-07-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Bump version to 1.1.4
- Add CHANGELOG entry for the macro token-paste highlighting fix (#26)

🤖 Generated with [Claude Code](https://claude.ai/code)