### PR TITLE
Fix comment and macro symbols being highlighted inside string literals

### DIFF
--- a/src/includePrepend.ts
+++ b/src/includePrepend.ts
@@ -5,15 +5,42 @@ import {
   TmLanguagePatternPatterns,
   TmLanguagePatternInclude,
   TmLanguagePatternNameOnly,
+  ContextKind,
+  CONTEXT_KINDS,
+  isContextKind,
 } from "./types";
+
+// Which global rules get prepended into a begin/end region, keyed by the
+// region's declared `contextKind` (default "code"). Inside pure text (ordinary
+// strings and comments) `//`, `/* */`, and git markers are literal characters,
+// not tokens, so nothing is injected. Only the `define `"..."` construct
+// expands macros, so it alone keeps the compiler-directive include.
+const INJECTED_INCLUDES: Record<ContextKind, string[]> = {
+  code: ["#comment", "#compiler-directive", "#git-conflict-marker"],
+  literal: [],
+  macroString: ["#compiler-directive"],
+};
 
 export class IncludePrependVisitor implements TmLanguageVisitor {
   visitBeginEnd(node: TmLanguagePatternBeginEnd): void {
-    if (node.name !== "comment.block.sv") {
+    // contextKind is authored in YAML, so validate the raw value rather than
+    // trusting the compile-time type, and never emit it into the grammar.
+    const raw: unknown = node.contextKind;
+    delete node.contextKind;
+
+    if (raw !== undefined && !isContextKind(raw)) {
+      throw new Error(
+        `Unknown contextKind "${String(raw)}"${
+          node.name ? ` on rule "${node.name}"` : ""
+        }. Expected one of: ${CONTEXT_KINDS.join(", ")}.`
+      );
+    }
+    const kind: ContextKind = raw ?? "code";
+
+    const includes = INJECTED_INCLUDES[kind];
+    if (includes.length > 0) {
       node.patterns = [
-        { include: "#comment" },
-        { include: "#compiler-directive" },
-        { include: "#git-conflict-marker" },
+        ...includes.map((include) => ({ include })),
         ...(node.patterns ?? []),
       ];
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,28 @@ export interface TmLanguage {
   repository: Record<string, TmLanguagePattern>;
 }
 
+// Build-only hint (stripped before output) telling IncludePrependVisitor which
+// global rules to inject into a region. Defaults to "code" when absent.
+//   code        - real code: comments, directives, and git markers may appear
+//   literal     - pure text (ordinary strings, comments): inject nothing
+//   macroString - the `define `"..."` construct, where macros do expand
+// See src/includePrepend.ts.
+//
+// The tuple is the single source of truth; the union is derived from it so the
+// two never drift, and isContextKind validates the raw string parsed from YAML.
+export const CONTEXT_KINDS = ["code", "literal", "macroString"] as const;
+export type ContextKind = (typeof CONTEXT_KINDS)[number];
+
+export function isContextKind(value: unknown): value is ContextKind {
+  return (
+    typeof value === "string" &&
+    (CONTEXT_KINDS as readonly string[]).includes(value)
+  );
+}
+
 export type TmLanguagePatternBeginEnd = {
   name?: string;
+  contextKind?: ContextKind;
   begin: string;
   end: string;
   beginCaptures?: {

--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -6858,6 +6858,7 @@ repository:
   # A.8.8 Strings
   triple-quoted-string-literal:
     name: string.quoted.triple.sv
+    contextKind: literal
     begin: '"""'
     end: '"""'
     beginCaptures:
@@ -6866,6 +6867,7 @@ repository:
       "0": { name: punctuation.definition.string.end.sv }
   string-literal:
     name: string.quoted.double.sv
+    contextKind: literal
     begin: \"
     end: \"
     beginCaptures:
@@ -6899,6 +6901,7 @@ repository:
       "3": { name: punctuation.separator.continuation.sv }
   block-comment:
     name: comment.block.sv
+    contextKind: literal
     begin: /\*
     end: \*/
     beginCaptures:
@@ -7322,6 +7325,7 @@ repository:
     patterns:
       # Escaped quotation mark
       - name: string.quoted.macro.sv
+        contextKind: macroString
         begin: \`\"
         end: \`\"
         beginCaptures:

--- a/tests/chapter-05/5.9-string-comment-literal.sv
+++ b/tests/chapter-05/5.9-string-comment-literal.sv
@@ -1,0 +1,21 @@
+// SYNTAX TEST "source-text.sv"
+
+// Comment-like sequences, git markers, and macro references inside an ordinary
+// string literal are all literal characters, not real tokens (IEEE 1800 5.9).
+// Macros only expand in the `define `"..."` construct, tested in chapter 22.
+
+module top ();
+
+initial begin
+  a = "line // still string";
+//         ^^ string.quoted.double.sv
+  b = "block /* still */ string";
+//          ^^ string.quoted.double.sv
+//                   ^^ string.quoted.double.sv
+  c = "marker ======= still string";
+//            ^^^^^^^ string.quoted.double.sv
+  d = "macro `FOO is literal here";
+//           ^^^^ string.quoted.double.sv
+end
+
+endmodule

--- a/tests/chapter-22/22.4--check_included_definitions.sv
+++ b/tests/chapter-22/22.4--check_included_definitions.sv
@@ -19,7 +19,7 @@
 module top ();
 initial begin
         $display(":assert:(`TWO_PLUS_TWO == 5)");
-//                         ^^^^^^^^^^^^^ meta.preprocessor.macro-name.sv
+//                         ^^^^^^^^^^^^^ string.quoted.double.sv
   $display(":assert:('%s' == '%s')", `define_var, "define_var");
 //                                   ^^^^^^^^^^^ meta.preprocessor.macro-name.sv
 end

--- a/tests/chapter-22/22.5.1--define-expansion_24.sv
+++ b/tests/chapter-22/22.5.1--define-expansion_24.sv
@@ -16,11 +16,11 @@
 module top ();
 `define HI Hello
 `define LO "`HI, world"
-//          ^^^ meta.preprocessor.macro-name.sv
+//          ^^^ string.quoted.double.sv
 `define H(x) "Hello, x"
 initial begin
   $display("`HI, world");
-//          ^^^ meta.preprocessor.macro-name.sv
+//          ^^^ string.quoted.double.sv
   $display(`LO);
 //         ^^^ meta.preprocessor.macro-name.sv
   $display(`H(world));

--- a/tests/chapter-22/misc.sv
+++ b/tests/chapter-22/misc.sv
@@ -48,6 +48,11 @@
 `define MY_KEYWORD posedge
 //                 ^^^^^^^ keyword.other.posedge.sv
 
+// Macros DO expand inside the `define `"..."` string construct, so a macro
+// reference there stays highlighted (unlike an ordinary "..." string).
+`define WRAP(v) `"start `INNER v`"
+//                      ^^^^^^ meta.preprocessor.macro-name.sv
+
 // Token paste `` on an uppercase macro argument, in an expression. Both the
 // operator and the pasted suffix must be highlighted (no bogus macro ref).
 `define TIE(NAME) assign NAME``_q = NAME``_d;


### PR DESCRIPTION
## Summary

- Comment-like sequences inside a string literal (e.g. `$fwrite(fd, "a // b /* c */ d")`) were highlighted as real comments. The `//` opened a line comment that ran past the closing quote, so the string never closed and the breakage cascaded down the file
- Root cause was in the build pipeline: `IncludePrependVisitor` prepended `#comment`, `#compiler-directive`, and `#git-conflict-marker` into every begin/end region, string literals included
- Ordinary `"..."` and `"""..."""` strings are now pure literal text — `//`, `/* */`, git markers, and macro references inside them are all literal. Per IEEE 1800, macros only expand in the `` `define `"..." `` construct, which keeps its macro highlighting
- Replaced the fragile scope-name check with an explicit per-rule `contextKind` (`code` / `literal` / `macroString`) declared in the grammar. The kinds come from a single `const` tuple, the type is derived from it, and the value is validated at build time so a typo throws instead of silently reintroducing the bug
- Updated two existing tests that had encoded the old macro-in-ordinary-string behavior, and added coverage in `tests/chapter-05/5.9-string-comment-literal.sv` and `tests/chapter-22/misc.sv`

🤖 Generated with [Claude Code](https://claude.ai/code)