### PR TITLE
Fix port/parameter connection dropped before a compiler directive

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -3876,7 +3876,9 @@ repository:
   named-parameter-assignment:
     name: meta.named-parameter-assignment.sv
     begin: (?<!\w)(\.)\s*(${identifier})\s*
-    end: (?=\)|,)
+    # Also close on a compiler directive (`else/`endif/...) so an assignment
+    # with no trailing comma before the directive does not swallow it.
+    end: (?=\)|,|`)
     beginCaptures:
       "1": { name: punctuation.definition.named-parameter-assignment.sv }
       "2": { name: variable.parameter.sv }
@@ -3922,7 +3924,9 @@ repository:
           "1": { name: punctuation.definition.wildcard.sv }
       - name: meta.named-port-connection.sv
         begin: (?<!\w)(\.)\s*(${identifier})\s*
-        end: (?=\)|,)
+        # Also close on a compiler directive (`else/`endif/...) so a connection
+        # with no trailing comma before the directive does not swallow it.
+        end: (?=\)|,|`)
         beginCaptures:
           "1": { name: punctuation.definition.named-port-connection.sv }
           "2": { name: variable.parameter.sv }

--- a/tests/chapter-23/23.3.2--instantiation-ifdef-ports.sv
+++ b/tests/chapter-23/23.3.2--instantiation-ifdef-ports.sv
@@ -1,0 +1,34 @@
+// SYNTAX TEST "source-text.sv"
+
+// Preprocessor conditionals inside a module instantiation port list. The port
+// connection right after `else must still be highlighted, even when the last
+// connection before the directive has no trailing comma (IEEE 1800 23.3.2).
+
+module top ();
+
+blk #(
+  .P(1),
+`ifdef SYNTH
+  .W(8)
+`else
+  .W(4)
+//^ punctuation.definition.named-parameter-assignment.sv
+// ^ variable.parameter.sv
+`endif
+) u_p ();
+
+blk u_i (
+  .clk(clk),
+`ifdef SYNTH
+  .a(w_a)
+`else
+  .a(),
+//^ punctuation.definition.named-port-connection.sv
+// ^ variable.parameter.sv
+  .b()
+//^ punctuation.definition.named-port-connection.sv
+// ^ variable.parameter.sv
+`endif
+);
+
+endmodule


### PR DESCRIPTION
## Summary

- Inside a module instantiation, a `` `ifdef ``/`` `else ``/`` `endif `` around the port (or parameter) list broke the connection right after the directive: its `.name` lost the `punctuation.definition.named-port-connection` and `variable.parameter` scopes
- Root cause: the `named-port-connection` and `named-parameter-assignment` regions only closed on `)` or `,`. When the last connection before a directive has no trailing comma, the region stayed open, swallowed the directive and the next connection's name, and only recovered at the following comma
- Close those regions on a backtick as well, so a connection followed by a compiler directive terminates cleanly
- Add `tests/chapter-23/23.3.2--instantiation-ifdef-ports.sv` covering both the port and parameter cases

Verified that macros inside a port expression (`.w(`WIDTH'd0)`), implicit connections (`.clk`), and directives with a leading comma are unaffected.

🤖 Generated with [Claude Code](https://claude.ai/code)