### PR TITLE
Fix variable name typed as a type with multiple unpacked dimensions

### DIFF
--- a/syntaxes/systemverilog.tmLanguage.yaml
+++ b/syntaxes/systemverilog.tmLanguage.yaml
@@ -1974,13 +1974,13 @@ repository:
   variable-decl-assignment:
     patterns:
       - include: "#dimension"
-      - match: (${identifier})\s*(?=\=|\,|\;|(\[[^\[\]]*?\]\s*(\=|\,|\;)))
+      - match: (${identifier})\s*(?=\=|\,|\;|((\[[^\[\]]*?\]\s*)+(\=|\,|\;)))
         captures:
           "1": { name: variable.other.sv }
   tagged-variable-decl-assignment:
     patterns:
       - include: "#dimension"
-      - match: (${identifier})\s*(?=\=|\,|\;|(\[[^\[\]]*?\]\s*(\=|\,|\;)))
+      - match: (${identifier})\s*(?=\=|\,|\;|((\[[^\[\]]*?\]\s*)+(\=|\,|\;)))
         captures:
           "1": { name: variable.other.constant.sv }
   class-new:

--- a/tests/chapter-08/misc.sv
+++ b/tests/chapter-08/misc.sv
@@ -1,0 +1,14 @@
+// SYNTAX TEST "source-text.sv"
+
+// A class property declared with two or more unpacked dimensions (e.g. an
+// associative array of queues) must highlight the property name as a variable,
+// not a type (IEEE 1800 8.5).
+
+class c;
+  t_e_t gvar[int][$];
+//      ^^^^ variable.other.sv
+  local t_e_t hvar[int][int][$];
+//            ^^^^ variable.other.sv
+  t_e_t svar[$];
+//      ^^^^ variable.other.sv
+endclass


### PR DESCRIPTION
## Summary

- A data declaration whose variable has two or more unpacked dimensions (e.g. `t_e_t v[int][$]`, an associative array of queues) highlighted the variable name as a type instead of a variable
- Root cause: the `variable-decl-assignment` lookahead only accepted a single `[...]` dimension before the `=`/`,`/`;` terminator. With two dimensions the lookahead failed, so the name fell through to the type-identifier rule and was scoped as a type. (Module-level declarations use a different path and were unaffected, so this only showed up on class properties.)
- Allow one or more dimensions in the lookahead, applied to both `variable-decl-assignment` and `tagged-variable-decl-assignment`
- Add `tests/chapter-08/misc.sv`

Verified no regression across other declaration forms (no dimension, initializer, multiple variables, packed + unpacked, etc.).

🤖 Generated with [Claude Code](https://claude.ai/code)