### PR TITLE
Bump version to 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-29
+
+### Fixed
+
+- Fix comment symbols (`//`, `/* */`) inside string literals being highlighted as comments
+- Fix a port or parameter connection dropped when a compiler directive (`` `else ``/`` `endif ``) follows a connection with no trailing comma
+- Fix a variable name highlighted as a type when it has two or more unpacked dimensions, e.g. `v[int][$]`
+
 ## [1.1.4] - 2026-07-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better-systemverilog-syntax",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "better-systemverilog-syntax",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "better-systemverilog-syntax",
   "displayName": "Better SystemVerilog Syntax",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Better syntax highlighting for SystemVerilog",
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary

- Bump version to 1.1.5
- Add CHANGELOG entries for the three fixes since 1.1.4: comment symbols inside strings (#28), port/parameter connection before a compiler directive (#29), and variable name typed as a type with multiple unpacked dimensions (#30)

🤖 Generated with [Claude Code](https://claude.ai/code)